### PR TITLE
filesystem.bats: fix restorecon tests

### DIFF
--- a/dom0/filesystem.bats
+++ b/dom0/filesystem.bats
@@ -12,14 +12,14 @@
 }
 
 @test "check config SELinux labels" {
-    run restorecon -Rnv /boot
+    run restorecon -Rnv /config
     count=$(echo ${output} | grep reset | wc -l)
 
     [ "$count" -eq 0 ]
 }
 
 @test "check storage SELinux labels" {
-    run restorecon -Rnv /boot
+    run restorecon -Rnv /storage
     count=$(echo ${output} | grep reset | wc -l)
 
     [ "$count" -eq 0 ]


### PR DESCRIPTION
The restorecon tests had a cut-and-paste error from the
first one and thus were not checking /config or /storage.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>