### PR TITLE
access_control.bats: add avc test

### DIFF
--- a/dom0/access_control.bats
+++ b/dom0/access_control.bats
@@ -14,6 +14,12 @@
     [ "${count}" -eq 0 ]
 }
 
+@test "no avc messages in /var/log/messages" {
+    count=$(grep avc:.*denied /var/log/messages|wc -l)
+
+    [ "${count}" -eq 0 ]
+}
+
 @test "check NDVM flask label" {
     run xec-vm -n Network -g flask-label
 


### PR DESCRIPTION
With current master, there are no avc: denied messages in /var/log/messages
after booting.  We want to keep it that way - all denials during normal
operation should either be dontaudit'd or allow'd in policy.  If you
have previously done development/debugging or accidentally tried running
a privileged command without first running nr, you can purge /var/log/messages
(e.g. cp /dev/null /var/log/messages) and reboot to test cleanly.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>