### PR TITLE
access_control.bats: update for rpc-proxy domain change

### DIFF
--- a/dom0/access_control.bats
+++ b/dom0/access_control.bats
@@ -87,9 +87,9 @@
     run ps -o label -C rpc-proxy
 
     [ "$status" -eq 0 ]
-    [ "${lines[1]}" = "system_u:system_r:dbusbouncer_t:s0" ]
-    [ "${lines[2]}" = "system_u:system_r:dbusbouncer_t:s0" ]
-    [ "${lines[3]}" = "system_u:system_r:dbusbouncer_t:s0" ]
+    [ "${lines[1]}" = "system_u:system_r:rpcproxy_t:s0" ]
+    [ "${lines[2]}" = "system_u:system_r:rpcproxy_t:s0" ]
+    [ "${lines[3]}" = "system_u:system_r:rpcproxy_t:s0" ]
 }
 
 @test "check vusb-daemon SELinux label" {


### PR DESCRIPTION
rpc-proxy was split into its own rpcproxy_t domain, so update
the SELinux process context test for rpc-proxy.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>