### PR TITLE
access_control.bats: update for rpc-proxy domain split

### DIFF
--- a/dom0/access_control.bats
+++ b/dom0/access_control.bats
@@ -88,8 +88,8 @@
 
     [ "$status" -eq 0 ]
     [ "${lines[1]}" = "system_u:system_r:rpcproxy_t:s0" ]
-    [ "${lines[2]}" = "system_u:system_r:rpcproxy_t:s0" ]
-    [ "${lines[3]}" = "system_u:system_r:rpcproxy_t:s0" ]
+    [ "${lines[2]}" = "system_u:system_r:rpcproxy_guest_t:s0" ]
+    [ "${lines[3]}" = "system_u:system_r:rpcproxy_websockets_t:s0" ]
 }
 
 @test "check vusb-daemon SELinux label" {


### PR DESCRIPTION
The rpcproxy_t domain has now been split into per-instance domains,
one for each of the three rpc-proxy processes.  Update the test
accordingly.

Signed-off-by: Stephen Smalley <sds@tycho.nsa.gov>